### PR TITLE
[Feat] field type 및 initial data 추가

### DIFF
--- a/src/field/model.ts
+++ b/src/field/model.ts
@@ -1,0 +1,10 @@
+type FieldType = "text" | "textarea" | "date" | "select" | "checkbox";
+
+type BaseField = {
+  label: string;
+  required: boolean;
+};
+
+type Field =
+  | (BaseField & { type: Exclude<FieldType, "select"> })
+  | (BaseField & { type: "select"; options: string[] });

--- a/src/field/model.ts
+++ b/src/field/model.ts
@@ -8,3 +8,37 @@ type BaseField = {
 type Field =
   | (BaseField & { type: Exclude<FieldType, "select"> })
   | (BaseField & { type: "select"; options: string[] });
+
+export const Fields = [
+  {
+    type: "text",
+    label: "이름",
+    required: true,
+  },
+  {
+    type: "text",
+    label: "주소",
+    required: false,
+  },
+  {
+    type: "textarea",
+    label: "메모",
+    required: false,
+  },
+  {
+    type: "date",
+    label: "가입일",
+    required: true,
+  },
+  {
+    type: "select",
+    label: "직업",
+    required: false,
+    options: ["개발자", "PO", "디자이너"],
+  },
+  {
+    type: "checkbox",
+    label: "이메일 수신 동의",
+    required: false,
+  },
+] satisfies Field[];

--- a/src/field/model.ts
+++ b/src/field/model.ts
@@ -41,4 +41,4 @@ export const Fields = [
     label: "이메일 수신 동의",
     required: false,
   },
-] satisfies Field[];
+] as const satisfies Field[];


### PR DESCRIPTION
- Field에 대한 타입과 initialData를 추가했습니다
- Field의 경우 공통 속성(type,label,required)를 가지면서도, type=select일 경우 options라는 속성이 필수로 필요하다고 판단하여 이를 만족시키는 유니온 타입으로 구성했습니다
- Fields라는 배열을 통해 초기 데이터를 생성했고, satisfies 키워드로 각 요소들의 타입을 체크합니다
- `as const` 를 통해 UI에서 타입이 필요할 경우에 더 정확하게 사용할 수 있습니다