### PR TITLE
[Feat/submit] 폼 제출 로직 및 마무리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "antd": "^5.22.2",
         "antd-style": "^3.7.1",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-hook-form": "^7.53.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.15.0",
@@ -5461,6 +5462,22 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.53.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.2.tgz",
+      "integrity": "sha512-YVel6fW5sOeedd1524pltpHX+jgU2u3DSDtXEaBORNdqiNrsX/nUI/iGXONegttg0mJVnfrIkiV0cmTU6Oo2xw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "antd": "^5.22.2",
     "antd-style": "^3.7.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-hook-form": "^7.53.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",

--- a/src/Page/mainPage.tsx
+++ b/src/Page/mainPage.tsx
@@ -10,6 +10,7 @@ import { useRef, useState } from "react";
 import { createColumns } from "./ui/columns";
 import { UserTableForm } from "./ui/UserTableForm";
 import { useTheme } from "antd-style";
+import { recordStorage } from "../entities/userTable/storage";
 
 //record 데이터를 antd table에 맞게 가공(key 추가)
 const initialDataSources: DataType[] = initialUserRecords.map(
@@ -21,6 +22,8 @@ const initialDataSources: DataType[] = initialUserRecords.map(
 
 const MainPage = () => {
   const [tableData, setTableData] = useState(initialDataSources);
+
+  const [storage, _] = useState(recordStorage);
 
   const token = useTheme();
 
@@ -59,23 +62,24 @@ const MainPage = () => {
   const formRef = useRef<{ submit: () => void }>(null);
 
   const onSubmitForm = (data: UserRecord) => {
-    if (editingRecord) {
-      setTableData((prev) =>
-        prev.map((record) =>
+    const newRecords = editingRecord
+      ? tableData.map((record) =>
           record.key === editingRecord.key
-            ? { ...data, key: record.key } // data(UserRecord)에 key를 추가
+            ? { ...data, key: record.key }
             : record
         )
-      );
-    } else {
-      setTableData((prev) => [...prev, { ...data, key: prev.length + 1 }]);
-    }
+      : [...tableData, { ...data, key: tableData.length + 1 }];
+
+    setTableData(newRecords);
     setOpen(false);
     setEditingRecord(null);
+    storage.setRecords(newRecords);
   };
 
   const onDeleteRecord = (key: string | React.Key) => {
-    setTableData((prev) => prev.filter((record) => record.key !== key));
+    const newRecords = tableData.filter((record) => record.key !== key);
+    setTableData(newRecords);
+    storage.setRecords(newRecords);
   };
 
   const onEditRecord = (record: DataType) => {

--- a/src/Page/mainPage.tsx
+++ b/src/Page/mainPage.tsx
@@ -59,7 +59,14 @@ const MainPage = () => {
         dataSource={tableData}
         columns={createColumns(tableData)}
       />
-      <Modal open={true} centered title="회원 추가" styles={{ ...modalStyles }}>
+      <Modal
+        open={true}
+        centered
+        title="회원 추가"
+        styles={{ ...modalStyles }}
+        okText="저장"
+        cancelText="취소"
+      >
         <Flex gap="18px">
           <UserTableForm />
         </Flex>

--- a/src/Page/mainPage.tsx
+++ b/src/Page/mainPage.tsx
@@ -67,9 +67,9 @@ const MainPage = () => {
         okText="저장"
         cancelText="취소"
       >
-        <Flex gap="18px">
+        <div style={{ width: "100%" }}>
           <UserTableForm />
-        </Flex>
+        </div>
       </Modal>
     </div>
   );

--- a/src/Page/mainPage.tsx
+++ b/src/Page/mainPage.tsx
@@ -43,6 +43,7 @@ const MainPage = () => {
       padding: `${token.paddingSM}px ${token.padding}px`,
       gap: "8px",
       background: `${token.colorFillAlter}`,
+      borderTop: `1px solid ${token.colorSplit}`,
     },
   };
 

--- a/src/Page/mainPage.tsx
+++ b/src/Page/mainPage.tsx
@@ -16,13 +16,12 @@ import { recordStorage } from "../entities/userTable/storage";
 const initialDataSources: DataType[] = initialUserRecords.map(
   (record, index) => ({
     ...record,
-    key: index + 1,
+    key: `${record.이름} ${index + 1}`,
   })
 );
 
 const MainPage = () => {
   const [tableData, setTableData] = useState(initialDataSources);
-
   const [storage, _] = useState(recordStorage);
 
   const token = useTheme();
@@ -59,21 +58,29 @@ const MainPage = () => {
     (typeof tableData)[number] | null
   >(null);
 
-  const formRef = useRef<{ submit: () => void }>(null);
+  const formRef = useRef<{ submit: () => void; reset: () => void }>(null);
 
   const onSubmitForm = (data: UserRecord) => {
     const newRecords = editingRecord
-      ? tableData.map((record) =>
-          record.key === editingRecord.key
-            ? { ...data, key: record.key }
-            : record
+      ? tableData.map(
+          (
+            record // 수정 모드
+          ) =>
+            record.key === editingRecord.key
+              ? { ...data, key: editingRecord.key } // 기존 key 유지
+              : record
         )
-      : [...tableData, { ...data, key: tableData.length + 1 }];
+      : [
+          // 추가 모드
+          ...tableData,
+          { ...data, key: `${data.이름} ${tableData.length + 1}` },
+        ];
 
     setTableData(newRecords);
     setOpen(false);
     setEditingRecord(null);
     storage.setRecords(newRecords);
+    formRef.current?.reset();
   };
 
   const onDeleteRecord = (key: string | React.Key) => {
@@ -140,12 +147,17 @@ const MainPage = () => {
         okText="저장"
         cancelText="취소"
         onOk={() => formRef.current?.submit()}
+        onCancel={() => {
+          setOpen(false);
+          formRef.current?.reset();
+          setEditingRecord(null);
+        }}
       >
         <div style={{ width: "100%" }}>
           <UserTableForm
             ref={formRef}
             onSubmit={onSubmitForm}
-            initialData={editingRecord || null}
+            editingData={editingRecord || null}
           />
         </div>
       </Modal>

--- a/src/Page/mainPage.tsx
+++ b/src/Page/mainPage.tsx
@@ -20,38 +20,38 @@ const initialDataSources: DataType[] = initialUserRecords.map(
   })
 );
 
+const modalStyles = (token: ReturnType<typeof useTheme>) => ({
+  header: {
+    display: "flex",
+    borderBottom: `1px solid ${token.colorBorderSecondary}`,
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    gap: "10px",
+    padding: `${token.paddingSM}px ${token.padding}px`,
+  },
+  body: {
+    display: "flex",
+    padding: `0px ${token.paddingContentHorizontalLG}px`,
+    flexDirection: "column" as const,
+    justifyContent: "center",
+    gap: "20px",
+  },
+  content: {
+    padding: 0,
+  },
+  footer: {
+    padding: `${token.paddingSM}px ${token.padding}px`,
+    gap: "8px",
+    background: `${token.colorFillAlter}`,
+    borderTop: `1px solid ${token.colorSplit}`,
+  },
+});
+
 const MainPage = () => {
   const [tableData, setTableData] = useState(initialDataSources);
   const [storage, _] = useState(recordStorage);
 
   const token = useTheme();
-
-  const modalStyles = {
-    header: {
-      display: "flex",
-      borderBottom: `1px solid ${token.colorBorderSecondary}`,
-      alignItems: "flex-start",
-      alignSelf: "stretch",
-      gap: "10px",
-      padding: `${token.paddingSM}px ${token.padding}px`,
-    },
-    body: {
-      display: "flex",
-      padding: `0px ${token.paddingContentHorizontalLG}px`,
-      flexDirection: "column" as const,
-      justifyContent: "center",
-      gap: "20px",
-    },
-    content: {
-      padding: 0,
-    },
-    footer: {
-      padding: `${token.paddingSM}px ${token.padding}px`,
-      gap: "8px",
-      background: `${token.colorFillAlter}`,
-      borderTop: `1px solid ${token.colorSplit}`,
-    },
-  };
 
   const [open, setOpen] = useState(false);
 
@@ -155,7 +155,7 @@ const MainPage = () => {
         open={open}
         centered
         title="회원 추가"
-        styles={{ ...modalStyles }}
+        styles={{ ...modalStyles(token) }}
         okText="저장"
         okButtonProps={{ disabled: !isFormValid }}
         cancelText="취소"

--- a/src/Page/mainPage.tsx
+++ b/src/Page/mainPage.tsx
@@ -54,11 +54,13 @@ const MainPage = () => {
   };
 
   const [open, setOpen] = useState(false);
+
+  //폼 관련 로직
+  const formRef = useRef<{ submit: () => void; reset: () => void }>(null);
+
   const [editingRecord, setEditingRecord] = useState<
     (typeof tableData)[number] | null
-  >(null);
-
-  const formRef = useRef<{ submit: () => void; reset: () => void }>(null);
+  >(null); //수정 시 레코드 저장
 
   const onSubmitForm = (data: UserRecord) => {
     const newRecords = editingRecord
@@ -93,6 +95,8 @@ const MainPage = () => {
     setEditingRecord(record);
     setOpen(true);
   };
+
+  const [isFormValid, setIsFormValid] = useState(false);
 
   return (
     <div>
@@ -145,6 +149,7 @@ const MainPage = () => {
         title="회원 추가"
         styles={{ ...modalStyles }}
         okText="저장"
+        okButtonProps={{ disabled: !isFormValid }}
         cancelText="취소"
         onOk={() => formRef.current?.submit()}
         onCancel={() => {
@@ -158,6 +163,7 @@ const MainPage = () => {
             ref={formRef}
             onSubmit={onSubmitForm}
             editingData={editingRecord || null}
+            onFormValuesChange={setIsFormValid}
           />
         </div>
       </Modal>

--- a/src/Page/mainPage.tsx
+++ b/src/Page/mainPage.tsx
@@ -100,7 +100,15 @@ const MainPage = () => {
 
   return (
     <div>
-      <Flex justify="space-between" align="center">
+      <Flex
+        justify="space-between"
+        align="center"
+        style={{
+          borderBottom: `1px solid ${token.colorSplit}`,
+          background: `${token.colorBgContainer}`,
+          padding: "8px 14px",
+        }}
+      >
         <Typography.Title level={5}>회원 목록</Typography.Title>
         <Button
           type="primary"

--- a/src/Page/mainPage.tsx
+++ b/src/Page/mainPage.tsx
@@ -1,6 +1,6 @@
-import { Button, Flex, Modal, Typography } from "antd";
+import { Button, Dropdown, Flex, Modal, Typography } from "antd";
 import { UserTable } from "./ui/UserTable";
-import { PlusOutlined } from "@ant-design/icons";
+import { MoreOutlined, PlusOutlined } from "@ant-design/icons";
 import type { DataType } from "./ui/type";
 import {
   initialUserRecords,
@@ -59,6 +59,10 @@ const MainPage = () => {
     setOpen(false);
   };
 
+  const onDeleteRecord = (key: string | React.Key) => {
+    setTableData((prev) => prev.filter((record) => record.key !== key));
+  };
+
   return (
     <div>
       <Flex justify="space-between" align="center">
@@ -73,7 +77,31 @@ const MainPage = () => {
       </Flex>
       <UserTable<DataType>
         dataSource={tableData}
-        columns={createColumns(tableData)}
+        columns={[
+          ...createColumns(tableData),
+          {
+            key: "action",
+            render: (text, record) => (
+              <Dropdown
+                menu={{
+                  items: [
+                    {
+                      key: "delete",
+                      label: "삭제",
+                      onClick: () => onDeleteRecord(record.key),
+                    },
+                  ],
+                }}
+              >
+                <Button
+                  type="text"
+                  content="icon-only"
+                  icon={<MoreOutlined />}
+                ></Button>
+              </Dropdown>
+            ),
+          },
+        ]}
       />
       <Modal
         open={open}

--- a/src/Page/mainPage.tsx
+++ b/src/Page/mainPage.tsx
@@ -2,8 +2,11 @@ import { Button, Flex, Modal, Typography } from "antd";
 import { UserTable } from "./ui/UserTable";
 import { PlusOutlined } from "@ant-design/icons";
 import type { DataType } from "./ui/type";
-import { initialUserRecords } from "../entities/userTable/model";
-import { useState } from "react";
+import {
+  initialUserRecords,
+  type UserRecord,
+} from "../entities/userTable/model";
+import { useRef, useState } from "react";
 import { createColumns } from "./ui/columns";
 import { UserTableForm } from "./ui/UserTableForm";
 import { useTheme } from "antd-style";
@@ -47,11 +50,24 @@ const MainPage = () => {
     },
   };
 
+  const [open, setOpen] = useState(false);
+
+  const formRef = useRef<{ submit: () => void }>(null);
+
+  const onSubmitForm = (data: UserRecord) => {
+    setTableData((prev) => [...prev, { ...data, key: prev.length + 1 }]);
+    setOpen(false);
+  };
+
   return (
     <div>
       <Flex justify="space-between" align="center">
         <Typography.Title level={5}>회원 목록</Typography.Title>
-        <Button type="primary" icon={<PlusOutlined />}>
+        <Button
+          type="primary"
+          icon={<PlusOutlined />}
+          onClick={() => setOpen(true)}
+        >
           추가
         </Button>
       </Flex>
@@ -60,15 +76,16 @@ const MainPage = () => {
         columns={createColumns(tableData)}
       />
       <Modal
-        open={true}
+        open={open}
         centered
         title="회원 추가"
         styles={{ ...modalStyles }}
         okText="저장"
         cancelText="취소"
+        onOk={() => formRef.current?.submit()}
       >
         <div style={{ width: "100%" }}>
-          <UserTableForm />
+          <UserTableForm ref={formRef} onSubmit={onSubmitForm} />
         </div>
       </Modal>
     </div>

--- a/src/Page/ui/UserTable.tsx
+++ b/src/Page/ui/UserTable.tsx
@@ -1,9 +1,7 @@
-import { Button, Flex, Table, Typography, type TableProps } from "antd";
+import { Table, type TableProps } from "antd";
 import { initialUserRecords } from "../../entities/userTable/model";
 import { useState } from "react";
-import { createColumns } from "./columns";
 import type { DataType } from "./type";
-import { PlusOutlined } from "@ant-design/icons";
 
 const initialDataSources: DataType[] = initialUserRecords.map(
   (record, index) => ({
@@ -21,6 +19,13 @@ export const UserTable = <T,>({ dataSource, columns }: UserTableProps<T>) => {
   const [tableData, setTableData] = useState(initialDataSources);
 
   return (
-    <Table<T> dataSource={dataSource} columns={columns} pagination={false} />
+    <Table<T>
+      dataSource={dataSource}
+      columns={columns}
+      pagination={false}
+      rowSelection={{
+        type: "checkbox",
+      }}
+    />
   );
 };

--- a/src/Page/ui/UserTable.tsx
+++ b/src/Page/ui/UserTable.tsx
@@ -1,14 +1,4 @@
 import { Table, type TableProps } from "antd";
-import { initialUserRecords } from "../../entities/userTable/model";
-import { useState } from "react";
-import type { DataType } from "./type";
-
-const initialDataSources: DataType[] = initialUserRecords.map(
-  (record, index) => ({
-    ...record,
-    key: index + 1,
-  })
-);
 
 interface UserTableProps<T> {
   dataSource: TableProps<T>["dataSource"];
@@ -16,8 +6,6 @@ interface UserTableProps<T> {
 }
 
 export const UserTable = <T,>({ dataSource, columns }: UserTableProps<T>) => {
-  const [tableData, setTableData] = useState(initialDataSources);
-
   return (
     <Table<T>
       dataSource={dataSource}

--- a/src/Page/ui/UserTableForm.tsx
+++ b/src/Page/ui/UserTableForm.tsx
@@ -2,7 +2,6 @@ import { fields, type UserRecord } from "../../entities/userTable/model";
 import { Form, Typography } from "antd";
 import { useTheme } from "antd-style";
 import { inputs } from "./columns";
-import { Controller, useForm } from "react-hook-form";
 import { cloneElement, forwardRef, useImperativeHandle } from "react";
 
 type inputType = UserRecord;
@@ -53,22 +52,11 @@ export const UserTableForm = forwardRef(
     },
     ref
   ) => {
-    const form = useForm<UserRecord>({
-      defaultValues:
-        initialData ||
-        fields.reduce(
-          (acc, field) => ({
-            ...acc,
-            [field.label]: field.defaultValue,
-          }),
-          {} as UserRecord
-        ),
-    });
-
-    const handleSubmit = form.handleSubmit(onSubmit);
+    const [form] = Form.useForm<UserRecord>();
 
     useImperativeHandle(ref, () => ({
-      submit: form.handleSubmit(onSubmit),
+      submit: (data: UserRecord) => onSubmit(data),
+      reset: () => form.resetFields(),
     }));
 
     return (
@@ -86,38 +74,19 @@ export const UserTableForm = forwardRef(
             {} as UserRecord
           )
         }
-        onFinish={handleSubmit}
+        form={form}
+        onFinish={(data) => onSubmit(data)}
       >
         {inputs.map((input) => {
           return (
-            <Controller
+            <Form.Item<inputType>
+              label={<FormLabel>{input.label}</FormLabel>}
               name={input.label}
               key={input.label}
-              control={form.control}
-              rules={{ required: input.required }}
-              render={({ field: { onChange, onBlur, value } }) => {
-                return (
-                  <Form.Item<inputType>
-                    label={<FormLabel>{input.label}</FormLabel>}
-                    name={input.label}
-                    key={input.label}
-                    required={input.required}
-                  >
-                    {input.type === "checkbox"
-                      ? cloneElement(input.render, {
-                          onChange,
-                          onBlur,
-                          checked: value,
-                        })
-                      : cloneElement(input.render, {
-                          onChange,
-                          onBlur,
-                          value,
-                        })}
-                  </Form.Item>
-                );
-              }}
-            />
+              required={input.required}
+            >
+              {input.render}
+            </Form.Item>
           );
         })}
       </Form>

--- a/src/Page/ui/UserTableForm.tsx
+++ b/src/Page/ui/UserTableForm.tsx
@@ -2,7 +2,7 @@ import { fields, type UserRecord } from "../../entities/userTable/model";
 import { Form, Typography } from "antd";
 import { useTheme } from "antd-style";
 import { inputs } from "./columns";
-import { forwardRef, useImperativeHandle } from "react";
+import { forwardRef, useEffect, useImperativeHandle } from "react";
 
 type inputType = UserRecord;
 
@@ -45,10 +45,10 @@ export const UserTableForm = forwardRef(
   (
     {
       onSubmit,
-      initialData,
+      editingData,
     }: {
       onSubmit: (data: UserRecord) => void;
-      initialData: UserRecord | null;
+      editingData: UserRecord | null;
     },
     ref
   ) => {
@@ -59,13 +59,9 @@ export const UserTableForm = forwardRef(
       reset: () => form.resetFields(),
     }));
 
-    return (
-      <Form
-        name="userTableForm"
-        layout="vertical"
-        requiredMark={RequiredMark}
-        initialValues={
-          initialData ||
+    useEffect(() => {
+      form.setFieldsValue(
+        editingData ||
           fields.reduce(
             (acc, field) => ({
               ...acc,
@@ -73,10 +69,16 @@ export const UserTableForm = forwardRef(
             }),
             {} as UserRecord
           )
-        }
+      );
+    }, [editingData]);
+
+    return (
+      <Form
+        name="userTableForm"
+        layout="vertical"
+        requiredMark={RequiredMark}
         form={form}
         onFinish={(data) => {
-          console.log(data);
           onSubmit(data);
         }}
       >

--- a/src/Page/ui/UserTableForm.tsx
+++ b/src/Page/ui/UserTableForm.tsx
@@ -88,6 +88,7 @@ export const UserTableForm = forwardRef(
               key={input.label}
               required={input.required}
               valuePropName={input.type === "checkbox" ? "checked" : "value"}
+              rules={[{ required: input.required }]}
             >
               {input.render}
             </Form.Item>

--- a/src/Page/ui/UserTableForm.tsx
+++ b/src/Page/ui/UserTableForm.tsx
@@ -2,7 +2,7 @@ import { fields, type UserRecord } from "../../entities/userTable/model";
 import { Form, Typography } from "antd";
 import { useTheme } from "antd-style";
 import { inputs } from "./columns";
-import { cloneElement, forwardRef, useImperativeHandle } from "react";
+import { forwardRef, useImperativeHandle } from "react";
 
 type inputType = UserRecord;
 
@@ -55,7 +55,7 @@ export const UserTableForm = forwardRef(
     const [form] = Form.useForm<UserRecord>();
 
     useImperativeHandle(ref, () => ({
-      submit: (data: UserRecord) => onSubmit(data),
+      submit: () => form.submit(),
       reset: () => form.resetFields(),
     }));
 
@@ -75,7 +75,10 @@ export const UserTableForm = forwardRef(
           )
         }
         form={form}
-        onFinish={(data) => onSubmit(data)}
+        onFinish={(data) => {
+          console.log(data);
+          onSubmit(data);
+        }}
       >
         {inputs.map((input) => {
           return (
@@ -84,6 +87,7 @@ export const UserTableForm = forwardRef(
               name={input.label}
               key={input.label}
               required={input.required}
+              valuePropName={input.type === "checkbox" ? "checked" : "value"}
             >
               {input.render}
             </Form.Item>

--- a/src/Page/ui/UserTableForm.tsx
+++ b/src/Page/ui/UserTableForm.tsx
@@ -46,9 +46,11 @@ export const UserTableForm = forwardRef(
     {
       onSubmit,
       editingData,
+      onFormValuesChange,
     }: {
       onSubmit: (data: UserRecord) => void;
       editingData: UserRecord | null;
+      onFormValuesChange?: (isValid: boolean) => void;
     },
     ref
   ) => {
@@ -80,6 +82,12 @@ export const UserTableForm = forwardRef(
         form={form}
         onFinish={(data) => {
           onSubmit(data);
+        }}
+        onValuesChange={(_, values) => {
+          // 필수 필드들의 값이 있는지 체크
+          console.log(values);
+          const isValid = Boolean(values.이름) && Boolean(values.가입일);
+          onFormValuesChange?.(isValid);
         }}
       >
         {inputs.map((input) => {

--- a/src/Page/ui/UserTableForm.tsx
+++ b/src/Page/ui/UserTableForm.tsx
@@ -84,8 +84,7 @@ export const UserTableForm = forwardRef(
           onSubmit(data);
         }}
         onValuesChange={(_, values) => {
-          // 필수 필드들의 값이 있는지 체크
-          console.log(values);
+          // 필수 필드들의 값이 있는지 체크 - 이름, 가입일
           const isValid = Boolean(values.이름) && Boolean(values.가입일);
           onFormValuesChange?.(isValid);
         }}

--- a/src/Page/ui/UserTableForm.tsx
+++ b/src/Page/ui/UserTableForm.tsx
@@ -1,4 +1,4 @@
-import { type UserRecord } from "../../entities/userTable/model";
+import { fields, type UserRecord } from "../../entities/userTable/model";
 import { Form, Typography } from "antd";
 import { useTheme } from "antd-style";
 import { inputs } from "./columns";
@@ -43,10 +43,32 @@ const RequiredMark = (
 };
 
 export const UserTableForm = () => {
-  const form = useForm<UserRecord>({});
+  const form = useForm<UserRecord>({
+    defaultValues: fields.reduce(
+      (acc, field) => ({
+        ...acc,
+        [field.label]: field.defaultValue,
+      }),
+      {} as UserRecord
+    ),
+  });
 
   return (
-    <Form name="userTableForm" layout="vertical" requiredMark={RequiredMark}>
+    <Form
+      name="userTableForm"
+      layout="vertical"
+      requiredMark={RequiredMark}
+      initialValues={fields.reduce(
+        (acc, field) => ({
+          ...acc,
+          [field.label]: field.defaultValue,
+        }),
+        {} as UserRecord
+      )}
+      onFinish={form.handleSubmit((values) => {
+        console.log(values);
+      })}
+    >
       {inputs.map((input) => {
         return (
           <Controller
@@ -54,7 +76,6 @@ export const UserTableForm = () => {
             key={input.label}
             control={form.control}
             render={({ field }) => {
-              console.log(field);
               return (
                 <Form.Item<inputType>
                   label={<FormLabel>{input.label}</FormLabel>}

--- a/src/Page/ui/UserTableForm.tsx
+++ b/src/Page/ui/UserTableForm.tsx
@@ -1,8 +1,11 @@
-import { fields, type UserRecord } from "../../entities/userTable/model";
-import { Form, Input, Typography } from "antd";
+import { type UserRecord } from "../../entities/userTable/model";
+import { Form, Typography } from "antd";
 import { useTheme } from "antd-style";
+import { inputs } from "./columns";
+import { Controller, useForm } from "react-hook-form";
+import { cloneElement } from "react";
 
-type FieldType = UserRecord;
+type inputType = UserRecord;
 
 export const FormLabel = ({ children }: { children: React.ReactNode }) => {
   const token = useTheme();
@@ -40,34 +43,29 @@ const RequiredMark = (
 };
 
 export const UserTableForm = () => {
-  const token = useTheme();
+  const form = useForm<UserRecord>({});
 
   return (
-    <Form
-      layout="vertical"
-      style={{ width: "100%" }}
-      requiredMark={RequiredMark}
-    >
-      {fields.map((field) => {
+    <Form name="userTableForm" layout="vertical" requiredMark={RequiredMark}>
+      {inputs.map((input) => {
         return (
-          <Form.Item<FieldType>
-            label={<FormLabel>{field.label}</FormLabel>}
-            name={field.label}
-            key={field.label}
-            rules={[
-              {
-                required: field.required,
-                message: `${field.label} is required`,
-              },
-            ]}
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              color: token.colorTextTertiary,
+          <Controller
+            name={input.label}
+            key={input.label}
+            control={form.control}
+            render={({ field }) => {
+              console.log(field);
+              return (
+                <Form.Item<inputType>
+                  label={<FormLabel>{input.label}</FormLabel>}
+                  name={input.label}
+                  key={input.label}
+                >
+                  {cloneElement(input.render, { ...field })}
+                </Form.Item>
+              );
             }}
-          >
-            <Input />
-          </Form.Item>
+          />
         );
       })}
     </Form>

--- a/src/Page/ui/UserTableForm.tsx
+++ b/src/Page/ui/UserTableForm.tsx
@@ -46,19 +46,23 @@ export const UserTableForm = forwardRef(
   (
     {
       onSubmit,
+      initialData,
     }: {
       onSubmit: (data: UserRecord) => void;
+      initialData: UserRecord | null;
     },
     ref
   ) => {
     const form = useForm<UserRecord>({
-      defaultValues: fields.reduce(
-        (acc, field) => ({
-          ...acc,
-          [field.label]: field.defaultValue,
-        }),
-        {} as UserRecord
-      ),
+      defaultValues:
+        initialData ||
+        fields.reduce(
+          (acc, field) => ({
+            ...acc,
+            [field.label]: field.defaultValue,
+          }),
+          {} as UserRecord
+        ),
     });
 
     const handleSubmit = form.handleSubmit(onSubmit);
@@ -72,13 +76,16 @@ export const UserTableForm = forwardRef(
         name="userTableForm"
         layout="vertical"
         requiredMark={RequiredMark}
-        initialValues={fields.reduce(
-          (acc, field) => ({
-            ...acc,
-            [field.label]: field.defaultValue,
-          }),
-          {} as UserRecord
-        )}
+        initialValues={
+          initialData ||
+          fields.reduce(
+            (acc, field) => ({
+              ...acc,
+              [field.label]: field.defaultValue,
+            }),
+            {} as UserRecord
+          )
+        }
         onFinish={handleSubmit}
       >
         {inputs.map((input) => {
@@ -88,7 +95,7 @@ export const UserTableForm = forwardRef(
               key={input.label}
               control={form.control}
               rules={{ required: input.required }}
-              render={({ field }) => {
+              render={({ field: { onChange, onBlur, value } }) => {
                 return (
                   <Form.Item<inputType>
                     label={<FormLabel>{input.label}</FormLabel>}
@@ -96,9 +103,17 @@ export const UserTableForm = forwardRef(
                     key={input.label}
                     required={input.required}
                   >
-                    {cloneElement(input.render, {
-                      ...field,
-                    })}
+                    {input.type === "checkbox"
+                      ? cloneElement(input.render, {
+                          onChange,
+                          onBlur,
+                          checked: value,
+                        })
+                      : cloneElement(input.render, {
+                          onChange,
+                          onBlur,
+                          value,
+                        })}
                   </Form.Item>
                 );
               }}

--- a/src/Page/ui/columns.tsx
+++ b/src/Page/ui/columns.tsx
@@ -7,6 +7,7 @@ import {
   emailField,
   dateField,
   type UserRecord,
+  fields,
 } from "../../entities/userTable/model";
 import type { DataType } from "./type";
 
@@ -38,6 +39,13 @@ export const createFilters = (records: DataType[]) => {
 export const createColumns = (
   records: DataType[]
 ): TableColumnsType<DataType> => {
+  if (records.length === 0) {
+    return fields.map((field) => ({
+      title: field.label,
+      dataIndex: field.label,
+    }));
+  }
+
   const filters = createFilters(records);
 
   return [

--- a/src/Page/ui/columns.tsx
+++ b/src/Page/ui/columns.tsx
@@ -110,5 +110,5 @@ export const inputs = [
       />
     ),
   },
-  { ...emailField, render: <Checkbox checked={emailField.defaultValue} /> },
+  { ...emailField, render: <Checkbox /> },
 ] as const;

--- a/src/Page/ui/columns.tsx
+++ b/src/Page/ui/columns.tsx
@@ -102,7 +102,6 @@ export const inputs = [
     placeholder: "Input",
     render: (
       <Select
-        defaultValue={jobField.defaultValue}
         options={jobField.options.map((option) => ({
           value: option,
           label: option,

--- a/src/Page/ui/columns.tsx
+++ b/src/Page/ui/columns.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, type TableColumnsType } from "antd";
+import { Checkbox, Input, Select, type TableColumnsType } from "antd";
 import {
   jobField,
   nameField,
@@ -80,3 +80,36 @@ export const createColumns = (
     },
   ];
 };
+
+export const inputs = [
+  {
+    ...nameField,
+    render: <Input placeholder="Input" />,
+  },
+  { ...addressField, render: <Input placeholder="Input" /> },
+  { ...memoField, render: <Input.TextArea size="large" rows={4} /> },
+  {
+    ...dateField,
+    render: (
+      <Input
+        type={dateField.type}
+        style={{ display: "inline-block", width: "auto" }}
+      />
+    ),
+  },
+  {
+    ...jobField,
+    placeholder: "Input",
+    render: (
+      <Select
+        defaultValue={jobField.defaultValue}
+        options={jobField.options.map((option) => ({
+          value: option,
+          label: option,
+        }))}
+        style={{ display: "inline-block", width: "auto" }}
+      />
+    ),
+  },
+  { ...emailField, render: <Checkbox checked={emailField.defaultValue} /> },
+] as const;

--- a/src/entities/userTable/storage.ts
+++ b/src/entities/userTable/storage.ts
@@ -14,7 +14,6 @@ class RecordStorage extends BrowserStorageModel<"record"> {
   public setRecords(newRecords: UserRecord[]) {
     this.records = newRecords;
     if (import.meta.env.VITE_STORAGE === "local-storage") {
-      console.log(newRecords);
       this.set("record", JSON.stringify(newRecords));
     }
   }

--- a/src/entities/userTable/storage.ts
+++ b/src/entities/userTable/storage.ts
@@ -1,0 +1,25 @@
+import { BrowserStorageModel } from "../../utils/browserStorageModel";
+import { initialUserRecords, type UserRecord } from "./model";
+
+class RecordStorage extends BrowserStorageModel<"record"> {
+  private records =
+    import.meta.env.VITE_STORAGE === "local-storage" && this.get("record")
+      ? JSON.parse(this.get("record")!)
+      : initialUserRecords;
+
+  public getRecords() {
+    return this.records;
+  }
+
+  public setRecords(newRecords: UserRecord[]) {
+    this.records = newRecords;
+    if (import.meta.env.VITE_STORAGE === "local-storage") {
+      console.log(newRecords);
+      this.set("record", JSON.stringify(newRecords));
+    }
+  }
+}
+
+export const recordStorage = new RecordStorage();
+
+recordStorage.setRecords(initialUserRecords);

--- a/src/reset.css
+++ b/src/reset.css
@@ -13,10 +13,6 @@ html {
 
 body {
   min-height: 100vh;
-  text-rendering: optimizeSpeed;
-  line-height: 1.5;
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    Oxygen, Ubuntu, Cantarell, sans-serif;
 }
 
 ul,
@@ -53,30 +49,4 @@ h4,
 h5,
 h6 {
   overflow-wrap: break-word;
-}
-
-/* 접근성을 위한 스킵 네비게이션 */
-.skip-nav {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
-.skip-nav:focus {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: auto;
-  height: auto;
-  padding: 1rem;
-  margin: 0;
-  clip: auto;
-  background: #fff;
-  z-index: 9999;
 }

--- a/src/utils/browserStorageModel.ts
+++ b/src/utils/browserStorageModel.ts
@@ -1,0 +1,21 @@
+type LocalStorage = typeof window.localStorage;
+
+export class BrowserStorageModel<T extends string> {
+  #storage: LocalStorage;
+
+  constructor(getStorage = (): LocalStorage => window.localStorage) {
+    this.#storage = getStorage();
+  }
+
+  protected get(key: T): string | null {
+    return this.#storage.getItem(key);
+  }
+
+  protected set(key: T, value: string) {
+    return this.#storage.setItem(key, value);
+  }
+
+  protected remove(key: T) {
+    this.#storage.removeItem(key);
+  }
+}


### PR DESCRIPTION
- 폼 제출과 나머지 요구사항(localStorage)을 구현했습니다
- 폼의 경우 로직은 react-hook-form, 디자인은 antd 디자인을 사용하려 계획했지만 두 로직간 충돌되는 부분이 존재하고 antd의 useForm로도 충분히 구현할 수 있을 거라 판단하여 변경하였습니다
- localStorage 저장 관련의 경우 타입 호환성을 위해 class를 생성하여 다루었습니다. 문제 요구조건이 단순 저장이라고만 판단하여 이를 컴포넌트 렌더링에 사용하지는 않았습니다